### PR TITLE
CI/CD: Update GitHub Action to run Python 2.7 with container

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,16 +9,11 @@ jobs:
   health:
     name: Check code health
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        python-version: [2.7]
+    container:
+      image: python:2.7.18-buster
     steps:
       - name: Checkout pysap
         uses: actions/checkout@v2
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python2 -m pip install --upgrade pip wheel


### PR DESCRIPTION
Until we've the migration to Python 3 complete and merge, build on GitHub Action using a container as support for Python 2.7 has been removed.