### PR TITLE
SAP MS: Adding some missing opcodes, fixing wrong structures and layouts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,18 +4,29 @@ Changelog
 v0.2.1.dev0 - in dev
 --------------------
 
+- `examples/ms_*.py`: Corrected Message Server response decoding, connection
+  validation, argument parsing, socket cleanup, and monitor command handling;
+  expanded `ms_monitor` with SAPMS monitor operations and removed non-SAPMS
+  aliases; added command and SAPMS argument completion.
+- `docs`: Updated the Message Server examples and regenerated the SAPMS packet
+  notebook with the new protocol structures.
+- `pysap/SAPMS.py`: Added ASCS gateway logon tags and corrected versioned
+  IP-to-name, ACL-check, file-reload, ASCS gateway status, and ASCS gateway
+  keepalive layouts.
+- `pysap/SAPMS.py`: Added layouts for statistics, open-request, NI trace,
+  server-generation-list, and log-counter operations.
 - `pysap/SAPMS.py`: Expanded Message Server enum coverage for domains, message
   types, errors, administration records, opcodes, properties, dump/file
   operations, and client status; added Message Server logon response parsing
-  and additional response fields.
+  and additional response fields. ([\#105](https://github.com/OWASP/pysap/pull/105))
 - `examples/ms_monitor.py`: Added named commands for logon data, logon groups,
   open requests, URL maps, counters, and related Message Server operations;
-  improved connection checks, argument parsing, and client-list output.
+  improved client-list output. ([\#105](https://github.com/OWASP/pysap/pull/105))
 - `docs/examples/message_server.rst`: Documented the expanded Message Server
-  monitor commands and their SNC variants.
+  monitor commands and their SNC variants. ([\#105](https://github.com/OWASP/pysap/pull/105))
 - `pysap/utils/console.py`: Improved console argument parsing, script
   execution, logging and resource cleanup; added `quit`, `q`, and EOF exit
-  handling and corrected table-formatting option forwarding.
+  handling and corrected table-formatting option forwarding. ([\#105](https://github.com/OWASP/pysap/pull/105))
 
 
 v0.2.0 - 2026-07-28

--- a/docs/examples/message_server.rst
+++ b/docs/examples/message_server.rst
@@ -42,7 +42,7 @@ The following is an example result of running the command:
     [*] Connected to the message server XXX.XXX.XXX.XXX:3901
     [*] Sending login packet:
     [*] Login OK, Server string: MSG_SERVER
-    ('[*] Sending dump info', 'MS_DUMP_CON')
+    [*] Sending dump info MS_DUMP_CON
     -------------------------- dump of mscon table -----------------------------
       NR ADDRESS > Unique key                      FIHDL NEXTREQ NEXTREP
     ----------------------------------------------------------------------------
@@ -50,7 +50,7 @@ The following is an example result of running the command:
     #entries = 0
 
 
-    ('[*] Sending dump info', 'MS_DUMP_PARAMS')
+    [*] Sending dump info MS_DUMP_PARAMS
 
     Release = 753
     Release no = 7530
@@ -285,7 +285,9 @@ perform on the Message Server. It connects with ``--remote-host`` and ``--remote
 with ``--domain`` and the client name can be changed with ``--client``. Packet logs can be written
 with ``--log-file``, console output can be written with ``--console-log``, and commands can be loaded
 from a file with ``--script``. A list of implemented commands can be obtained by running ``help``
-inside the console.
+inside the console. Interactive sessions support tab completion for command
+names and for known SAPMS values such as clients, dump and reload operations,
+logon types, and property identifiers.
 
 Example usage:
 
@@ -296,24 +298,50 @@ Example usage:
 The console provides the standard ``help``, ``history``, ``options``,
 ``script``, ``exit`` and ``quit`` commands. Message Server monitor operations
 include client and logon-group listings, logon data retrieval, hardware and
-security queries, statistics, counters, server shutdown operations, and dump
-commands. Frequently used expert operations are available as named commands:
+security queries, client registration updates, statistics, counters, server
+shutdown operations, property management, and dump commands. Frequently used
+expert operations are available as named commands:
 
 .. code-block:: console
 
     pysap's console> logon_group_list
     pysap's console> get_logon PUBLIC
     pysap's console> logon_data_lb PUBLIC
+    pysap's console> set_logon 6 PUBLIC 127.0.0.1 50000 HTTP host
+    pysap's console> del_logon 6 PUBLIC
     pysap's console> open_requests
     pysap's console> dump_url_map
     pysap's console> dump_url_prefixes
     pysap's console> dump_url_handler
     pysap's console> counter_dump <counter>
     pysap's console> logon_types
+    pysap's console> statistics_get
+    pysap's console> nitrace_get <client>
+    pysap's console> server_generation_list
+    pysap's console> subsystem_list
+    pysap's console> log_counter_read
+    pysap's console> log_counter_reset
+    pysap's console> ip_port_to_name 127.0.0.1 3200
+    pysap's console> change_ip 127.0.0.2
+    pysap's console> set_security_key SERVER secret
+    pysap's console> text_get SERVER
+    pysap's console> text_set SERVER "description"
+    pysap's console> property_get 0 1
+    pysap's console> property_set 0 1 "description"
+    pysap's console> property_delete 0 1
+    pysap's console> file_reload 4
+    pysap's console> noop
+    pysap's console> soft_shutdown
 
-The SNC group-list and logon-data commands are also exposed as
-``logon_group_list_snc``, ``logon_data_snc`` and ``logon_data_lb_snc``. Their
-availability depends on the Message Server's configured SNC groups.
+``dump all`` runs every dump command that takes no additional operand. The
+``MS_DUMP_MSADM`` and ``MS_DUMP_COUNTER`` commands are skipped and can be run
+individually with a client ID or counter name.
+
+The native ``msmon`` SNC group-list and logon-cache maintenance operations use
+the Lg API rather than SAPMS packets and are therefore not exposed by this
+SAPMS-only console. SNC logon data retrieval remains available through
+``logon_data_snc`` and ``logon_data_lb_snc`` when the server has configured SNC
+groups.
 
 
 ``ms_observer``

--- a/examples/ms_change_param.py
+++ b/examples/ms_change_param.py
@@ -40,7 +40,7 @@ def parse_options():
                   "(ms/monitor=1)[1] and the internal port should be reachable. Keep in mind that some of the " \
                   "parameters are not dynamic and can't be changed using this method. If the parameter value is not " \
                   "specified, the script retrieve the current value. " \
-                  "[1] https://help.sap.com/saphelp_nw70/helpdata/en/4e/cffdb69d10424e97eb1d993b1e2cfd/content.htm"
+                  "[1] https://help.sap.com/docs/ABAP_PLATFORM_NEW/77b3972f873044acb3a70258f3984c64/47c56a6938fb2d65e10000000a42189c.html?q=ms/monitor#administration-using-profile-parameters"
 
     usage = "%(prog)s [options] -d <remote host> -n <parameter name> [-l <parameter value>]"
 
@@ -104,6 +104,10 @@ def main():
     print("[*] Sending login packet")
     response = conn.sr(p)[SAPMS]
 
+    if response.errorno != 0:
+        conn.close()
+        raise RuntimeError("Message Server login failed with error %d" % response.errorno)
+
     server_string = response.fromname
     print("[*] Login performed, server string: %s" % (server_string.decode("utf-8", errors="replace").strip() if isinstance(server_string, bytes) else server_string))
 
@@ -121,13 +125,16 @@ def main():
         print("[*] Response:")
         response.show()
 
+    if not response.adm_records or response.adm_records[0].errorno != 0:
+        conn.close()
+        raise RuntimeError("Unable to retrieve parameter")
     param_old_value = response.adm_records[0].parameter
     if isinstance(param_old_value, bytes):
         param_old_value = param_old_value.decode("utf-8", errors="replace").strip("\x00").strip()
     print("[*] Parameter %s" % param_old_value)
 
     # If a parameter change was requested, send an ADM AD_SHARED_PARAMETER request
-    if options.param_value:
+    if options.param_value is not None:
         print("[*] Changing parameter value from: %s to: %s" % (param_old_value,
                                                                 options.param_value))
 
@@ -150,6 +157,8 @@ def main():
             print("[*] Error requesting parameter change (error number %d)" % response.adm_records[0].errorno)
         else:
             print("[*] Parameter changed for the current session !")
+
+    conn.close()
 
 
 if __name__ == "__main__":

--- a/examples/ms_dump_info.py
+++ b/examples/ms_dump_info.py
@@ -92,6 +92,10 @@ def main():
     print("[*] Sending login packet:")
     response = conn.sr(p)[SAPMS]
 
+    if response.errorno != 0:
+        conn.close()
+        raise RuntimeError("Message Server login failed with error %d" % response.errorno)
+
     server_string = response.fromname
     print("[*] Login OK, Server string: %s" % (server_string.decode("utf-8", errors="replace").strip() if isinstance(server_string, bytes) else server_string))
 
@@ -112,10 +116,13 @@ def main():
 
         if response.opcode_error != 0:
             print("Error:", ms_opcode_error_values[response.opcode_error])
-        value = response.opcode_value
+            continue
+        value = response.dump_response
         if isinstance(value, bytes):
             value = value.rstrip(b'\x00').decode('utf-8', errors='replace')
         print(value)
+
+    conn.close()
 
 
 if __name__ == "__main__":

--- a/examples/ms_dump_param.py
+++ b/examples/ms_dump_param.py
@@ -97,6 +97,9 @@ def main():
         p = SAPMS(flag=0x00, iflag=0x08, toname=client_string, fromname=client_string)
         print("[*] Sending login packet:")
         response = conn.sr(p)[SAPMS]
+        if response.errorno != 0:
+            conn.close()
+            raise RuntimeError("Message Server login failed with error %d" % response.errorno)
         server_string = response.fromname
         print("[*] Login OK, Server string: %s\n" % (server_string.decode("utf-8", errors="replace").strip() if isinstance(server_string, bytes) else server_string))
 
@@ -113,7 +116,7 @@ def main():
                     # param2c = the SAP parameter to check
                     # check_type = EQUAL, SUP, INF, REGEX, <none>
                     # value2c = the expect value for 'ok' status
-                    (param2c, check_type, value2c) = line.split(':')
+                    (param2c, check_type, value2c) = line.split(':', 2)
                     status = '[!]'
 
                     # create request
@@ -123,6 +126,10 @@ def main():
 
                     # send request
                     respond = conn.sr(p)[SAPMS]
+                    if (not respond.adm_records or
+                            respond.adm_records[0].errorno != 0):
+                        print("[!] %s = ACCESS_DENIED_OR_UNAVAILABLE" % param2c)
+                        continue
                     param_val = respond.adm_records[0].parameter
                     if isinstance(param_val, bytes):
                         param_val = param_val.decode('utf-8', errors='replace').rstrip('\x00')
@@ -156,8 +163,10 @@ def main():
             exit(0)
         except ValueError as e:
             import traceback; traceback.print_exc()
-            print("Invalid parameters file format or access denied: %s" % e)
+            print("Invalid parameters file format: %s" % e)
             exit(0)
+        finally:
+            conn.close()
 
 
 if __name__ == '__main__':

--- a/examples/ms_listener.py
+++ b/examples/ms_listener.py
@@ -91,6 +91,9 @@ def main():
 
     print("[*] Sending login packet")
     response = conn.sr(p)[SAPMS]
+    if response.errorno != 0:
+        conn.close()
+        raise RuntimeError("Message Server login failed with error %d" % response.errorno)
 
     fromname = response.fromname
     print("[*] Login performed, server string: %s" % (fromname.decode("utf-8", errors="replace").strip() if isinstance(fromname, bytes) else fromname))
@@ -110,6 +113,8 @@ def main():
         print("[*] Connection error")
     except KeyboardInterrupt:
         print("[*] Cancelled by the user")
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/examples/ms_messager.py
+++ b/examples/ms_messager.py
@@ -96,16 +96,20 @@ def main():
 
     print("[*] Sending login packet")
     response = conn.sr(p)[SAPMS]
+    if response.errorno != 0:
+        conn.close()
+        raise RuntimeError("Message Server login failed with error %d" % response.errorno)
 
     fromname = response.fromname
     print("[*] Login performed, server string: %s" % (fromname.decode("utf-8", errors="replace").strip() if isinstance(fromname, bytes) else fromname))
 
     # Sends a message to another client
     p = SAPMS(flag=0x02, iflag=0x01, domain=domain, toname=options.target, fromname=client_string, opcode=1)
-    p /= Raw(options.message)
+    p /= Raw(options.message.encode("utf-8"))
 
     print("[*] Sending packet to: %s" % options.target)
     conn.send(p)
+    conn.close()
 
 
 if __name__ == "__main__":

--- a/examples/ms_monitor.py
+++ b/examples/ms_monitor.py
@@ -18,6 +18,7 @@
 #
 
 # Standard imports
+import ipaddress
 import logging
 from argparse import ArgumentParser
 from socket import error as SocketError
@@ -30,7 +31,8 @@ from pysap.SAPMS import (SAPMS, ms_client_status_values, ms_opcode_error_values,
                          ms_dump_command_values, SAPMSCounter, ms_opcode_values,
                          ms_errorno_values, SAPMSProperty, ms_property_id_values,
                          SAPMSAdmRecord, ms_domain_values_inv,
-                         ms_logon_type_values, SAPMSLogon)
+                         ms_file_reload_values, ms_logon_type_values,
+                         SAPMSLogon)
 from pysap.SAPRouter import SAPRoutedStreamSocket
 
 
@@ -71,6 +73,48 @@ class SAPMSMonitorConsole(BaseConsole):
             if value is not None:
                 return value
         return []
+
+    def _show_clients(self, response):
+        """Display and retain a versioned Message Server client list."""
+        clients = self._get_clients(response)
+        table = [["#", "Client Name", "Host", "Service", "IPv4", "IPv6",
+                  "ServNo", "State", "Services"]]
+        instance = self.runtimeoptions["server_string"]
+        for index, client in enumerate(clients):
+            status = getattr(client, "status", None)
+            if status == 1:
+                instance = self._decode(client.client)
+            table.append([str(index), self._decode(client.client),
+                          self._decode(client.host),
+                          self._decode(client.service), client.hostaddrv4,
+                          client.hostaddrv6 if "hostaddrv6" in client.fields else None,
+                          str(client.servno),
+                          ms_client_status_values.get(status, str(status))
+                          if status is not None else "",
+                          str(client.msgtype).replace("+", " ")
+                          if client.msgtype else "-"])
+        self._tabulate(table)
+        self.clients = clients
+        self.runtimeoptions["instance"] = instance
+        self._debug("Server instance: %s" % instance)
+
+    @staticmethod
+    def _complete_values(text, values):
+        """Complete a token from a finite set of SAPMS values."""
+        return sorted(value for value in (str(item) for item in values)
+                      if value.startswith(text))
+
+    @staticmethod
+    def _completion_arg(line, begidx):
+        """Return the zero-based argument currently being completed."""
+        return max(0, len(line[:begidx].split()) - 1)
+
+    def _complete_client_ids(self, text):
+        return self._complete_values(text, range(len(self.clients)))
+
+    def _complete_client_names(self, text):
+        return self._complete_values(
+            text, (self._decode(client.client) for client in self.clients))
 
     # Helper for crafting packets
     def _build(self, flag, iflag, **args):
@@ -184,33 +228,7 @@ class SAPMSMonitorConsole(BaseConsole):
         if response is None:
             return
 
-        clients = self._get_clients(response)
-
-        # Print clients table
-        table = [["#", "Client Name", "Host", "Service", "IPv4", "IPv6", "ServNo", "State", "Services"]]
-        instance = self.runtimeoptions["server_string"]
-        i = 0
-        for client in clients:
-            status = getattr(client, "status", None)
-            if status == 1:
-                instance = self._decode(client.client)
-            table.append([str(i),
-                          self._decode(client.client),
-                          self._decode(client.host),
-                          self._decode(client.service),
-                          client.hostaddrv4,
-                          client.hostaddrv6 if "hostaddrv6" in client.fields else None,
-                          str(client.servno),
-                          ms_client_status_values.get(status, str(status)) if status is not None else "",
-                          str(client.msgtype).replace("+", " ") if client.msgtype else "-"])
-            i += 1
-        self._tabulate(table)
-
-        # Store clients for further use
-        self.clients = clients
-
-        self._debug("Server instance: %s" % instance)
-        self.runtimeoptions["instance"] = instance
+        self._show_clients(response)
 
     def do_hardware_id(self, args):
         """ Retrieve the installation's hardware ID. """
@@ -222,14 +240,16 @@ class SAPMSMonitorConsole(BaseConsole):
         """ Get Security Key by name. """
         response = self._send_simple(0x02, 0x01, opcode=0x08, security_name=args)
         if response:
-            self._print("Security Name: %s" % response.security_name)
             self._print("Security Key: %s" % response.security_key)
+
+    def complete_get_security_by_name(self, text, line, begidx, endidx):
+        return self._complete_client_names(text)
 
     def do_get_security_by_ip(self, args):
         """ Get Security Key by ip/port. Options <IPv4 address> <port> """
 
         try:
-            ip, port = args.split(" ")
+            ip, port = args.split()
             port = int(port)
         except ValueError:
             self._error("Wrong parameters !")
@@ -238,10 +258,67 @@ class SAPMSMonitorConsole(BaseConsole):
         # Send MS_GET_SECURITY
         response = self._send_simple(0x02, 0x01, opcode=0x09, security2_addressv4=ip, security2_port=port)
         if response:
-            self._print("Security IPv4 Address: %s" % response.security2_addressv4)
-            self._print("Security Port: %s" % response.security2_port)
             self._print("Security Key: %s" % response.security2_key)
-            self._print("Security IPv6 Address: %s" % response.security2_addressv6)
+
+    def do_set_security_key(self, args):
+        """Set a client security key. Options: <client name> <key>"""
+        arguments = self._parse_args(args)
+        if arguments is None:
+            return
+        if len(arguments) != 2 or len(arguments[1].encode("utf-8")) > 256:
+            self._error("Wrong parameters ! Specify client name and a key up to 256 bytes")
+            return
+        if self._send_simple(0x02, 0x01, opcode=0x07,
+                             security_name=arguments[0],
+                             security_key=arguments[1]):
+            self._print("Security key set")
+
+    def complete_set_security_key(self, text, line, begidx, endidx):
+        if self._completion_arg(line, begidx) == 0:
+            return self._complete_client_names(text)
+        return []
+
+    def do_ip_port_to_name(self, args):
+        """Resolve an IP address and port. Options: <IP address> <port>"""
+        arguments = self._parse_args(args)
+        if arguments is None:
+            return
+        try:
+            address = ipaddress.ip_address(arguments[0])
+            port = int(arguments[1])
+            if len(arguments) != 2 or not 0 <= port <= 65535:
+                raise ValueError
+        except (IndexError, ValueError):
+            self._error("Wrong parameters ! Specify an IP address and port")
+            return
+
+        request = {"opcode": 0x46,
+                   "opcode_version": 1 if address.version == 4 else 2,
+                   "ip_to_name_port": port}
+        if address.version == 4:
+            request["ip_to_name_address4"] = str(address)
+        else:
+            request["ip_to_name_address6"] = str(address)
+        response = self._send_simple(0x02, 0x01, **request)
+        if response:
+            self._print("Client name: %s" % self._decode(response.ip_to_name))
+
+    def do_change_ip(self, args):
+        """Change this client's registered IP address. Options: <IP address>"""
+        try:
+            address = ipaddress.ip_address((args or "").strip())
+        except ValueError:
+            self._error("Invalid IP address")
+            return
+        request = {"opcode": 0x06,
+                   "opcode_version": 1 if address.version == 4 else 2}
+        if address.version == 4:
+            request["change_ip_addressv4"] = str(address)
+        else:
+            request.update(change_ip_addressv4="0.0.0.0",
+                           change_ip_addressv6=str(address))
+        if self._send_simple(0x02, 0x01, **request):
+            self._print("Registered IP address changed")
 
     def do_dump(self, args):
         """ Dump information. Options [<dump command> | all] """
@@ -252,7 +329,11 @@ class SAPMSMonitorConsole(BaseConsole):
 
         if arguments == ["all"]:
             for key in ms_dump_command_values:
-                self.do_dump(key)
+                if key in (1, 12):
+                    self._print("Skipping %s: requires an argument" %
+                                ms_dump_command_values[key])
+                    continue
+                self._do_dump(key, [])
             return
 
         try:
@@ -264,9 +345,23 @@ class SAPMSMonitorConsole(BaseConsole):
             self._error("all: dumps all the available information")
             return
 
+        self._do_dump(command, arguments[1:])
+
+    def complete_dump(self, text, line, begidx, endidx):
+        argument = self._completion_arg(line, begidx)
+        if argument == 0:
+            return self._complete_values(
+                text, list(ms_dump_command_values) + ["all"])
+        tokens = line[:begidx].split()
+        if argument == 1 and len(tokens) > 1 and tokens[1] == "1":
+            return self._complete_client_ids(text)
+        return []
+
+    def _do_dump(self, command, arguments):
+        """Execute one parsed dump command."""
         if command == 1:  # MS_DUMP_MSADM
             try:
-                client_id = int(arguments[1])
+                client_id = int(arguments[0])
                 client = self.clients[client_id]
             except (ValueError, IndexError):
                 self._error("Wrong parameters ! Specify client ID")
@@ -276,7 +371,7 @@ class SAPMSMonitorConsole(BaseConsole):
                                          dump_name=self._decode(client.client))
         elif command == 12:  # MS_DUMP_COUNTER
             try:
-                counter = arguments[1]
+                counter = arguments[0]
             except IndexError:
                 self._error("Wrong parameters ! Specify counter number")
                 return
@@ -288,7 +383,7 @@ class SAPMSMonitorConsole(BaseConsole):
             response = self._send_simple(0x02, 0x01, opcode=0x1e, dump_dest=0x02, dump_command=command)
 
         if response:
-            value = response.opcode_value
+            value = response.dump_response
             if isinstance(value, bytes):
                 value = value.rstrip(b'\x00').decode('utf-8', errors='replace')
             self._print("Dump information:\n%s" % value)
@@ -296,11 +391,12 @@ class SAPMSMonitorConsole(BaseConsole):
     def do_open_requests(self, args):
         """List open Message Server requests."""
         response = self._send_simple(0x02, 0x01, opcode=0x14)
-        if response:
-            value = response.opcode_value
-            if isinstance(value, bytes):
-                value = value.rstrip(b"\x00").decode("utf-8", errors="replace")
-            self._print("Open requests:\n%s" % value)
+        if response and response.open_requests is not None:
+            table = [["#", "Raw request record"]]
+            table.extend([str(index), request.data.hex()]
+                         for index, request in enumerate(
+                             response.open_requests.requests))
+            self._tabulate(table)
 
     def do_dump_url_map(self, args):
         """Dump the Message Server URL map."""
@@ -375,6 +471,11 @@ class SAPMSMonitorConsole(BaseConsole):
         """Retrieve logon data. Options: <group name> [<logon type>]"""
         return self._get_logon(args)
 
+    def complete_get_logon(self, text, line, begidx, endidx):
+        if self._completion_arg(line, begidx) == 1:
+            return self._complete_values(text, ms_logon_type_values)
+        return []
+
     def do_logon_data(self, args):
         """Alias for :meth:`get_logon`."""
         return self.do_get_logon(args)
@@ -391,22 +492,99 @@ class SAPMSMonitorConsole(BaseConsole):
         """Retrieve SNC load-balanced logon data. Options: <group name>"""
         return self._get_logon(args, fixed_type=1)
 
+    complete_logon_data = complete_get_logon
+
     def do_logon_group_list(self, args):
-        """List logon groups."""
-        return self.do_client_list(args)
+        """Dump GUI and RFC logon-group lists."""
+        self.do_dump("31")
+        self.do_dump("32")
 
-    def do_logon_group_list_snc(self, args):
-        """List logon groups with SNC information."""
-        return self.do_client_list(args)
+    def do_set_logon(self, args):
+        """Set logon data. Options: <type> <group> <address> <port> <protocol> <host> [misc]"""
+        arguments = self._parse_args(args)
+        if arguments is None:
+            return
+        if len(arguments) not in (6, 7):
+            self._error("Wrong parameters ! Specify type, group, address, port, protocol, host and optional misc")
+            return
+        try:
+            logon_type = int(arguments[0])
+            address = ipaddress.ip_address(arguments[2])
+            port = int(arguments[3])
+            if logon_type not in ms_logon_type_values or not 0 <= port <= 65535:
+                raise ValueError
+        except ValueError:
+            self._error("Invalid logon type, address or port")
+            return
+        values = {"type": logon_type, "logonname": arguments[1],
+                  "port": port, "prot": arguments[4], "host": arguments[5],
+                  "misc": arguments[6] if len(arguments) == 7 else ""}
+        if address.version == 4:
+            values.update(address=str(address), address6_length=-1)
+        else:
+            values.update(address="0.0.0.0", address6_length=16,
+                          address6=str(address))
+        if self._send_simple(0x02, 0x01, opcode=0x2b,
+                             logon=SAPMSLogon(**values)):
+            self._print("Logon data set")
 
-    def do_logon_memory_free(self, args):
-        """Release cached logon data on the server."""
-        self._print("The Message Server exposes no separate free-logon-data request; refreshing the group list.")
-        return self.do_client_list(args)
+    def complete_set_logon(self, text, line, begidx, endidx):
+        if self._completion_arg(line, begidx) == 0:
+            return self._complete_values(text, ms_logon_type_values)
+        return []
 
-    def do_logon_reload(self, args):
-        """Force a refresh of the Message Server logon data."""
-        return self.do_client_list(args)
+    def do_del_logon(self, args):
+        """Delete logon data. Options: <type> <group>"""
+        arguments = self._parse_args(args)
+        if arguments is None:
+            return
+        try:
+            logon_type = int(arguments[0])
+            if len(arguments) != 2 or logon_type not in ms_logon_type_values:
+                raise ValueError
+        except (IndexError, ValueError):
+            self._error("Wrong parameters ! Specify logon type and group")
+            return
+        request = SAPMSLogon(type=logon_type, logonname=arguments[1],
+                             address6_length=-1)
+        if self._send_simple(0x02, 0x01, opcode=0x2d, logon=request):
+            self._print("Logon data deleted")
+
+    def complete_del_logon(self, text, line, begidx, endidx):
+        if self._completion_arg(line, begidx) == 0:
+            return self._complete_values(text, ms_logon_type_values)
+        return []
+
+    def do_text_set(self, args):
+        """Set client text. Options: <client name> <text>"""
+        arguments = self._parse_args(args)
+        if arguments is None:
+            return
+        if len(arguments) != 2 or len(arguments[1].encode("utf-8")) > 80:
+            self._error("Wrong parameters ! Specify client name and text up to 80 bytes")
+            return
+        if self._send_simple(0x02, 0x01, opcode=0x22,
+                             text_name=arguments[0],
+                             text_value=arguments[1]):
+            self._print("Client text set")
+
+    def do_text_get(self, args):
+        """Get client text. Options: <client name>"""
+        arguments = self._parse_args(args)
+        if arguments is None:
+            return
+        if len(arguments) != 1:
+            self._error("Wrong parameters ! Specify client name")
+            return
+        response = self._send_simple(0x02, 0x01, opcode=0x23,
+                                     text_name=arguments[0])
+        if response:
+            self._print("Client text: %s" % self._decode(response.text_value))
+
+    def complete_text_get(self, text, line, begidx, endidx):
+        return self._complete_client_names(text)
+
+    complete_text_set = complete_set_security_key
 
     def do_server_parameters(self, args):
         """ Dump server parameters. """
@@ -469,10 +647,54 @@ class SAPMSMonitorConsole(BaseConsole):
 
         # Send MS_GET_STATISTIC
         response = self._send_simple(0x02, 0x01, opcode=0x11)
-        # TODO: Statistics fields are not correctly defined, just showing the
-        # complete packet now
         if response:
-            response.show()
+            self._print("Statistics version %d: %d bytes" %
+                        (response.opcode_version, len(response.stats)))
+
+    def do_nitrace_get(self, args):
+        """Get NI trace settings for a Message Server client."""
+        response = self._send_simple(
+            0x02, 0x01, opcode=0x3f, nitrace_client=args,
+            nitrace_operation=0, nitrace_level=0)
+        if response:
+            self._print("NI trace operation=%d level=%d" %
+                        (response.nitrace_operation,
+                         response.nitrace_level))
+
+    def complete_nitrace_get(self, text, line, begidx, endidx):
+        return self._complete_client_names(text)
+
+    def do_server_generation_list(self, args):
+        """List clients from the active server generation."""
+        response = self._send_simple(0x02, 0x01, opcode=0x4f)
+        if response:
+            clients = getattr(response, "clients_v%d" %
+                              response.opcode_version, None)
+            if response.opcode_version == 1:
+                clients = response.clients
+            self._print("Server generation clients: %d" %
+                        len(clients or []))
+
+    def do_subsystem_list(self, args):
+        """List Message Server clients in the current subsystem."""
+        response = self._send_simple(0x02, 0x01, opcode=0x4d)
+        if response:
+            self._show_clients(response)
+
+    def do_log_counter_read(self, args):
+        """Read one page of Message Server log counters."""
+        response = self._send_simple(0x02, 0x01, opcode=0x50)
+        if response and response.log_counter is not None:
+            counter = response.log_counter
+            self._print("Log counters: index=%d count=%d end=%d" %
+                        (counter.index, counter.count, counter.end))
+            for index, record in enumerate(counter.records):
+                self._print("%d: %s" % (index, record.data.hex()))
+
+    def do_log_counter_reset(self, args):
+        """Reset Message Server log counters."""
+        if self._send_simple(0x02, 0x01, opcode=0x51):
+            self._print("Log counters reset")
 
     def do_network_buffer_dump(self, args):
         """ Dump network buffer. """
@@ -489,6 +711,29 @@ class SAPMSMonitorConsole(BaseConsole):
         response = self._send_simple(0x02, 0x01, opcode=0x13)
         if response:
             self._print("Network buffer reset")
+
+    def do_noop(self, args):
+        """Send a Message Server keepalive request."""
+        if self._send_simple(0x02, 0x01, opcode=0x21):
+            self._print("NOOP sent")
+
+    def do_file_reload(self, args):
+        """Reload a Message Server file/table. Options: <reload operation>"""
+        try:
+            operation = int((args or "").strip())
+            if operation not in ms_file_reload_values:
+                raise ValueError
+        except ValueError:
+            self._error("Invalid reload operation ! Valid values:")
+            for key, value in sorted(ms_file_reload_values.items()):
+                self._error("%d: %s" % (key, value))
+            return
+        if self._send_simple(0x02, 0x01, opcode=0x1f,
+                             file_reload=operation):
+            self._print("Reloaded %s" % ms_file_reload_values[operation])
+
+    def complete_file_reload(self, text, line, begidx, endidx):
+        return self._complete_values(text, ms_file_reload_values)
 
     def do_get_codepage(self, args):
         """ Get code page. """
@@ -531,7 +776,7 @@ class SAPMSMonitorConsole(BaseConsole):
     def do_counter_increment(self, args):
         """ Increment Counter. Options: <counter> <value> """
         try:
-            counter, count = args.split(" ")
+            counter, count = args.split()
             count = int(count)
         except ValueError:
             self._error("Invalid parameters !")
@@ -542,7 +787,7 @@ class SAPMSMonitorConsole(BaseConsole):
     def do_counter_decrement(self, args):
         """ Decrement Counter. Options: <counter> <value> """
         try:
-            counter, count = args.split(" ")
+            counter, count = args.split()
             count = int(count)
         except ValueError:
             self._error("Invalid parameters !")
@@ -558,10 +803,10 @@ class SAPMSMonitorConsole(BaseConsole):
         """ Server disconnect. Options: <client id> <reason> """
 
         try:
-            client_id, reason = args.split(" ", 2)
+            client_id, reason = args.split(None, 1)
             client_id = int(client_id)
             client = self.clients[client_id]
-        except (ValueError, KeyError):
+        except (ValueError, KeyError, IndexError):
             self._error("Invalid parameters !")
             self.do_client_list(None)
             return
@@ -577,10 +822,10 @@ class SAPMSMonitorConsole(BaseConsole):
         """ Server shutdown. Options: <client id> <reason> """
 
         try:
-            client_id, reason = args.split(" ", 2)
+            client_id, reason = args.split(None, 1)
             client_id = int(client_id)
             client = self.clients[client_id]
-        except (ValueError, KeyError):
+        except (ValueError, KeyError, IndexError):
             self._error("Invalid parameters !")
             self.do_client_list(None)
             return
@@ -596,10 +841,10 @@ class SAPMSMonitorConsole(BaseConsole):
         """ Server soft shutdown. Options: <client id> <reason> """
 
         try:
-            client_id, reason = args.split(" ", 2)
+            client_id, reason = args.split(None, 1)
             client_id = int(client_id)
             client = self.clients[client_id]
-        except (ValueError, KeyError):
+        except (ValueError, KeyError, IndexError):
             self._error("Invalid parameters !")
             self.do_client_list(None)
             return
@@ -611,14 +856,30 @@ class SAPMSMonitorConsole(BaseConsole):
         if response:
             self._print("Server soft shutdown")
 
+    def complete_server_client(self, text, line, begidx, endidx):
+        if self._completion_arg(line, begidx) == 0:
+            return self._complete_client_ids(text)
+        return []
+
+    complete_server_disconnect = complete_server_client
+    complete_server_shutdown = complete_server_client
+    complete_server_soft_shutdown = complete_server_client
+
+    def do_soft_shutdown(self, args):
+        """Request a soft shutdown of the Message Server."""
+        if self._send_simple(0x02, 0x01, opcode=0x1d):
+            self._print("Message Server soft shutdown requested")
+
     def do_property_get(self, args):
         """ Get property. Options: <client id> <prop id> """
 
         try:
-            prop_client, prop_id = args.split(" ")
+            prop_client, prop_id = args.split()
             prop_client = self.clients[int(prop_client)]
             prop_id = int(prop_id)
-        except (ValueError, KeyError):
+            if prop_id not in ms_property_id_values:
+                raise ValueError
+        except (ValueError, KeyError, IndexError):
             self._error("Invalid parameters !")
             return
 
@@ -632,8 +893,92 @@ class SAPMSMonitorConsole(BaseConsole):
                                                         self._decode(prop_client.client)))
             response.property.show()
 
+    def do_property_set(self, args):
+        """Set a property. Options: <client id> <property id> <value>"""
+        arguments = self._parse_args(args)
+        if arguments is None:
+            return
+        try:
+            client = self.clients[int(arguments[0])]
+            property_id = int(arguments[1])
+            values = arguments[2:]
+            if property_id not in ms_property_id_values:
+                raise ValueError
+            prop_args = {"client": client.client, "id": property_id}
+            if property_id == 2:
+                if len(values) != 2:
+                    raise ValueError
+                prop_args.update(logon=int(values[0]), value=values[1])
+            elif property_id == 3:
+                if len(values) != 1:
+                    raise ValueError
+                address = ipaddress.ip_address(values[0])
+                if address.version == 4:
+                    prop_args["address"] = str(address)
+                else:
+                    prop_args["address6"] = str(address)
+            elif property_id == 4:
+                if len(values) != 2:
+                    raise ValueError
+                prop_args.update(param=values[0], param_value=values[1])
+            elif property_id == 5:
+                if len(values) != 2:
+                    raise ValueError
+                prop_args.update(service=int(values[0]),
+                                 service_value=int(values[1]))
+            elif property_id == 7:
+                if len(values) != 4:
+                    raise ValueError
+                prop_args.update(release=values[0], patchno=int(values[1]),
+                                 supplvl=int(values[2]), platform=int(values[3]))
+            else:
+                if len(values) != 1:
+                    raise ValueError
+                prop_args["raw_value"] = values[0]
+        except (IndexError, KeyError, ValueError):
+            self._error("Invalid client, property id or property value")
+            return
+
+        prop = SAPMSProperty(**prop_args)
+        if self._send_simple(0x02, 0x01, opcode=0x43, property=prop):
+            self._print("Property %s set for client %s" %
+                        (ms_property_id_values[property_id],
+                         self._decode(client.client)))
+
+    def do_property_delete(self, args):
+        """Delete a property. Options: <client id> <property id>"""
+        try:
+            client_id, property_id = (args or "").split()
+            client = self.clients[int(client_id)]
+            property_id = int(property_id)
+            if property_id not in ms_property_id_values:
+                raise ValueError
+        except (IndexError, KeyError, ValueError):
+            self._error("Invalid client or property id")
+            return
+        prop = SAPMSProperty(client=client.client, id=property_id)
+        if self._send_simple(0x02, 0x01, opcode=0x45, property=prop):
+            self._print("Property %s deleted for client %s" %
+                        (ms_property_id_values[property_id],
+                         self._decode(client.client)))
+
+    def complete_property(self, text, line, begidx, endidx):
+        argument = self._completion_arg(line, begidx)
+        if argument == 0:
+            return self._complete_client_ids(text)
+        if argument == 1:
+            return self._complete_values(text, ms_property_id_values)
+        return []
+
+    complete_property_get = complete_property
+    complete_property_set = complete_property
+    complete_property_delete = complete_property
+
     def do_parameter_get(self, args):
         """ Get parameter value. Options: <parameter name> """
+
+        if not self._require_connection():
+            return
 
         parameter_name = args
 
@@ -643,18 +988,22 @@ class SAPMSMonitorConsole(BaseConsole):
 
         response = self.connection.sr(p)[SAPMS]
 
-        if response:
+        if response.adm_records and response.adm_records[0].errorno == 0:
             param = response.adm_records[0].parameter
             if isinstance(param, bytes):
                 param = param.decode("utf-8", errors="replace").strip("\x00").strip()
             self._print("Parameter value: %s" % param)
+        else:
+            self._error("Error retrieving the parameter !")
 
     def do_parameter_set(self, args):
         """ Set parameter value (requires monitor mode enabled).
             Options: <parameter name> <parameter value> """
 
+        if not self._require_connection():
+            return
         try:
-            parameter_name, parameter_value = args.split(" ", 2)
+            parameter_name, parameter_value = args.split(None, 1)
         except ValueError:
             self._error("Invalid parameters !")
             return
@@ -667,22 +1016,40 @@ class SAPMSMonitorConsole(BaseConsole):
 
         response = self.connection.sr(p)[SAPMS]
 
-        if response:
-            if response.adm_records[0].errorno != 0:
-                self._error("Error changing the parameter !")
-            else:
-                self._print("Parameter %s set to %s !" % (parameter_name,
-                                                          parameter_value))
+        if not response.adm_records or response.adm_records[0].errorno != 0:
+            self._error("Error changing the parameter !")
+        else:
+            self._print("Parameter %s set to %s !" % (parameter_name,
+                                                       parameter_value))
 
     def do_check_acl(self, args):
-        """ Set parameter value (requires monitor mode enabled).
-            Options: <parameter name> <parameter value> """
+        """ Check the effective Message Server ACL.
+            Options: [IP address] """
 
-        response = self._send_simple(0x02, 0x01, opcode=71, opcode_version=1, opcode_charset=0)[SAPMS]
+        address = args.strip() if args else ""
+        request = {"opcode": 71, "opcode_version": 1,
+                   "opcode_charset": 0}
+        if address:
+            try:
+                parsed_address = ipaddress.ip_address(address)
+            except ValueError:
+                self._error("Invalid IP address")
+                return
+            if parsed_address.version == 4:
+                address = "::ffff:%s" % parsed_address
+            else:
+                address = str(parsed_address)
+            request.update(opcode_version=2,
+                           check_acl_address=address)
+
+        response = self._send_simple(0x02, 0x01, **request)
 
         if response:
             if response.error_code:
-                self._error("Error checking ACL, code %d" % response.error_code)
+                error = ms_opcode_error_values.get(response.error_code,
+                                                   "UNKNOWN")
+                self._error("Error checking ACL: %s (%d)" %
+                            (error, response.error_code))
             else:
                 acl = response.acl
                 if isinstance(acl, bytes):

--- a/examples/ms_observer.py
+++ b/examples/ms_observer.py
@@ -91,6 +91,9 @@ def main():
     print("[*] Sending login packet")
     p = SAPMS(flag=0x00, iflag=0x08, domain=domain, toname=client_string, fromname=client_string)
     response = conn.sr(p)[SAPMS]
+    if response.errorno != 0:
+        conn.close()
+        raise RuntimeError("Message Server login failed with error %d" % response.errorno)
 
     server_string = response.fromname
     print("[*] Login performed, server string: %s" % (server_string.decode("utf-8", errors="replace").strip() if isinstance(server_string, bytes) else server_string))
@@ -135,7 +138,7 @@ def main():
               opcode_version=0x68)
     response = conn.sr(p)[SAPMS]
     for client in get_clients(response):
-        if client.client != client_string:
+        if decode_field(client.client) != decode_field(client_string):
             clients.append(("LIST", client))
             print_client("Client", client)
 
@@ -176,6 +179,7 @@ def main():
                                                                       decode_field(client.host),
                                                                       decode_field(client.service),
                                                                       client.servno))
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/pysap/SAPMS.py
+++ b/pysap/SAPMS.py
@@ -19,12 +19,12 @@
 # External imports
 from scapy.layers.inet import TCP
 from scapy.packet import Packet, bind_layers
-from scapy.fields import (ByteField, ConditionalField, StrFixedLenField, FlagsField,
-                          IPField, ShortField, IntField, StrField, PacketListField,
+from scapy.fields import (ByteField, ByteEnumField, ConditionalField, StrFixedLenField, FlagsField,
+                          IPField, ShortField, ShortEnumField, IntField, StrField, PacketListField,
                           FieldLenField, PacketField, StrLenField, IntEnumField,
                           ByteEnumKeysField, ShortEnumKeysField, Field,
                           PacketLenField, XByteField, SignedIntField,
-                          MultipleTypeField)
+                          LongField, MultipleTypeField)
 from scapy.layers.inet6 import IP6Field
 # Custom imports
 from pysap.SAPNI import SAPNI
@@ -186,7 +186,6 @@ ms_adm_opcode_values = {
     0x10: "AD_WPCONF2",
     0x11: "AD_GENERAL2",
     0x12: "AD_SET_LIST_PARAM",
-    # Compatibility label; absent from the release-916 canonical table.
     0x13: "AD_DUMP_STATUS",
     0x14: "AD_RZL",
     0x15: "AD_RZL_STRG",  # *
@@ -213,7 +212,7 @@ ms_adm_opcode_values = {
     0x32: "AD_WALL_DELETE",
     0x33: "AD_WALL_MODIFY",
     0x34: "AD_SERVER_STATE",
-    0x3c: "AD_SELFIDENT",  # *
+    0x3c: "AD_SELFIDENT",
     0x3d: "AD_DP_TRACE_CHANGE",
     0x3e: "AD_DP_DUMP_NIHDL",
     0x3f: "AD_DP_CALL_DELAYED",
@@ -232,7 +231,7 @@ ms_adm_opcode_values = {
     0x4c: "AD_OAUTHBUFFRESET",
     0x4d: "AD_RESET_BUFFERED_TABLE",
     0x4e: "AD_SESSION_REQUEST",
-    0x4f: "AD_PROFILE2",
+    0x4f: "AD_PROFILE2",  # *s
     0x50: "AD_RSCP_ASYNC",
     0x51: "AD_BATCH_INFO",
     0x52: "AD_SOFT_CANCEL",
@@ -542,6 +541,16 @@ ms_logon_type_values = {
 """Message Server Logon type values"""
 
 
+ms_ascs_gateway_tag_values = {
+    0: "MS_ASCS_GW_END",
+    1: "MS_ASCS_GW_INTERNAL_PORT",
+    2: "MS_ASCS_GW_EXTERNAL_PORT",
+    3: "MS_ASCS_GW_PID",
+    4: "MS_ASCS_GW_NODE_ADDRESS",
+}
+"""Message Server ASCS gateway logon tag values"""
+
+
 ms_client_status_values = {
     0: "MS_STATE_UNKNOWN",
     1: "ACTIVE",
@@ -803,6 +812,39 @@ class SAPMSStat3(PacketNoPadded):
     ]
 
 
+class SAPMSOpenRequest(PacketNoPadded):
+    """Opaque 88-byte entry returned by ``MS_OPEN_REQ_LST``."""
+    name = "SAP Message Server Open Request"
+    fields_desc = [StrFixedLenField("data", b"", 88)]
+
+
+class SAPMSOpenRequestList(PacketNoPadded):
+    """Reply body returned by ``MS_OPEN_REQ_LST``."""
+    name = "SAP Message Server Open Request List"
+    fields_desc = [
+        PacketListField("requests", None, SAPMSOpenRequest),
+    ]
+
+
+class SAPMSLogCounterRecord(PacketNoPadded):
+    """Opaque 48-byte entry in an ``MS_READ_LG_COUNTER`` page."""
+    name = "SAP Message Server Log Counter Record"
+    fields_desc = [StrFixedLenField("data", b"", 48)]
+
+
+class SAPMSLogCounter(PacketNoPadded):
+    """Paged reply body returned by ``MS_READ_LG_COUNTER``."""
+    name = "SAP Message Server Log Counter"
+    fields_desc = [
+        IntField("index", 0),
+        FieldLenField("count", None, count_of="records", fmt="!I"),
+        ByteField("end", 1),
+        StrFixedLenField("padding", b"\x00" * 3, 3),
+        PacketListField("records", None, SAPMSLogCounterRecord,
+                        count_from=lambda pkt: pkt.count),
+    ]
+
+
 class SAPMSCounter(PacketNoPadded):
     """SAP Message Server Counter packet.
 
@@ -813,6 +855,45 @@ class SAPMSCounter(PacketNoPadded):
         StrFixedLenField("uuid", b"", 40),
         IntField("count", 0),
         IntField("no", 0),
+    ]
+
+
+class SAPMSASCSGatewayLogonTag(PacketNoPadded):
+    """One fixed-width tag in an ``MS_ASCS_GW_LOGON`` payload."""
+    name = "SAP Message Server ASCS Gateway Logon Tag"
+    fields_desc = [
+        ByteEnumField("tag", 0, ms_ascs_gateway_tag_values),
+        ConditionalField(
+            MultipleTypeField([
+                (IntField("value", 0), lambda pkt: pkt.tag in [1, 2]),
+                (LongField("value", 0), lambda pkt: pkt.tag == 3),
+                (IP6Field("value", "::"), lambda pkt: pkt.tag == 4),
+            ], StrField("value", b"")),
+            lambda pkt: pkt.tag != 0),
+    ]
+
+
+def _next_ascs_gateway_logon_tag(_pkt, _lst, previous, _remain):
+    """Continue after known value tags; zero and unknown tags terminate."""
+    if previous is None or previous.tag in [1, 2, 3, 4]:
+        return SAPMSASCSGatewayLogonTag
+    return None
+
+
+class SAPMSASCSGatewayLogon(PacketNoPadded):
+    """Tagged ASCS gateway payload used by opcodes 82 and 83."""
+    name = "SAP Message Server ASCS Gateway Logon"
+    fields_desc = [
+        PacketListField("tags", [], SAPMSASCSGatewayLogonTag,
+                        next_cls_cb=_next_ascs_gateway_logon_tag),
+    ]
+
+
+class SAPMSASCSGatewayKeepalive(PacketNoPadded):
+    """Opaque request payload used by ``MS_ASCS_GW_KEEPALIVE``."""
+    name = "SAP Message Server ASCS Gateway Keepalive"
+    fields_desc = [
+        StrFixedLenField("data", b"", 0x1030),
     ]
 
 
@@ -903,6 +984,9 @@ class SAPMSProperty(Packet):
         ConditionalField(IntField("patchno", 0), lambda pkt:pkt.id in [0x07]),
         ConditionalField(IntField("supplvl", 0), lambda pkt:pkt.id in [0x07]),
         ConditionalField(IntField("platform", 0), lambda pkt:pkt.id in [0x07]),
+
+        # Properties without a publicly known typed value layout
+        ConditionalField(StrField("raw_value", b""), lambda pkt:pkt.id not in [0x02, 0x03, 0x04, 0x05, 0x07]),
     ]
 
 
@@ -1213,8 +1297,8 @@ class SAPMS(Packet):
         ConditionalField(ByteEnumKeysField("opcode_error", 0x00, ms_opcode_error_values), lambda pkt:pkt.iflag in [0x00, 0x01, 0x02, 0x7]),
         ConditionalField(ByteField("opcode_version", 0x01), lambda pkt:pkt.iflag in [0x00, 0x01, 0x02, 0x07]),
         ConditionalField(ByteField("opcode_charset", 0x03), lambda pkt:pkt.iflag in [0x00, 0x01, 0x02, 0x07]),
-        ConditionalField(StrField("opcode_value", b""), lambda pkt:pkt.iflag in [0x00, 0x01] and pkt.opcode not in [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x11, 0x1c, 0x1e, 0x1f, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x43, 0x44, 0x45, 0x46, 0x47, 0x4a, 0x4d, 0x4e]),
-        ConditionalField(StrField("opcode_trailer", b""), lambda pkt:pkt.iflag in [0x00, 0x01] and pkt.opcode not in [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x11, 0x1c, 0x1e, 0x1f, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x43, 0x44, 0x45, 0x46, 0x47, 0x4a, 0x4d, 0x4e]),
+        ConditionalField(StrField("opcode_value", b""), lambda pkt:pkt.iflag in [0x00, 0x01] and pkt.opcode not in [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x11, 0x14, 0x1c, 0x1e, 0x1f, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x3f, 0x43, 0x44, 0x45, 0x46, 0x47, 0x4a, 0x4d, 0x4e, 0x4f, 0x50, 0x51, 0x52, 0x53, 0x54]),
+        ConditionalField(StrField("opcode_trailer", b""), lambda pkt:pkt.iflag in [0x00, 0x01] and pkt.opcode not in [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x11, 0x14, 0x1c, 0x1e, 0x1f, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x3f, 0x43, 0x44, 0x45, 0x46, 0x47, 0x4a, 0x4d, 0x4e, 0x4f, 0x50, 0x51, 0x52, 0x53, 0x54]),
 
         # Dispatcher info
         ConditionalField(ByteField("dp_version", 0x0), lambda pkt:pkt.opcode == 0x0 or (pkt.opcode_version == 0x00 and pkt.opcode_charset == 0x00)),
@@ -1233,10 +1317,10 @@ class SAPMS(Packet):
         ConditionalField(PacketListField("adm_records", None, SAPMSAdmRecord), lambda pkt:pkt.iflag in [0x00, 0x02, 0x05, 0x07] or pkt.opcode == 0x0),
 
         # Server List fields
-        ConditionalField(PacketListField("clients", None, SAPMSClient1), lambda pkt:pkt.opcode in [0x02, 0x03, 0x04, 0x05, 0x4d] and pkt.opcode_version == 0x01),
-        ConditionalField(PacketListField("clients_v2", None, SAPMSClient2), lambda pkt:pkt.opcode in [0x02, 0x03, 0x04, 0x05, 0x4d] and pkt.opcode_version == 0x02),
-        ConditionalField(PacketListField("clients_v3", None, SAPMSClient3), lambda pkt:pkt.opcode in [0x02, 0x03, 0x04, 0x05, 0x4d] and pkt.opcode_version == 0x03),
-        ConditionalField(PacketListField("clients_v4", None, SAPMSClient4), lambda pkt:pkt.opcode in [0x02, 0x03, 0x04, 0x05, 0x4d] and pkt.opcode_version == 0x04),
+        ConditionalField(PacketListField("clients", None, SAPMSClient1), lambda pkt:pkt.opcode in [0x02, 0x03, 0x04, 0x05, 0x4d, 0x4f] and pkt.opcode_version == 0x01),
+        ConditionalField(PacketListField("clients_v2", None, SAPMSClient2), lambda pkt:pkt.opcode in [0x02, 0x03, 0x04, 0x05, 0x4d, 0x4f] and pkt.opcode_version == 0x02),
+        ConditionalField(PacketListField("clients_v3", None, SAPMSClient3), lambda pkt:pkt.opcode in [0x02, 0x03, 0x04, 0x05, 0x4d, 0x4f] and pkt.opcode_version == 0x03),
+        ConditionalField(PacketListField("clients_v4", None, SAPMSClient4), lambda pkt:pkt.opcode in [0x02, 0x03, 0x04, 0x05, 0x4d, 0x4f] and pkt.opcode_version == 0x04),
 
         # Change IP fields
         ConditionalField(IPField("change_ip_addressv4", "0.0.0.0"), lambda pkt:pkt.opcode == 0x06),
@@ -1252,20 +1336,26 @@ class SAPMS(Packet):
         ConditionalField(PacketListField("counters", None, SAPMSCounter), lambda pkt:pkt.opcode in [0x2a]),
 
         # Security Key 1 fields
-        ConditionalField(StrFixedLenField("security_name", None, 40), lambda pkt:pkt.opcode in [0x07, 0x08]),
-        ConditionalField(StrFixedLenField("security_key", None, 256), lambda pkt:pkt.opcode in [0x07, 0x08]),
+        ConditionalField(StrFixedLenField("security_name", None, 40), lambda pkt:pkt.opcode == 0x07 or (pkt.opcode == 0x08 and pkt.flag == 0x02)),
+        ConditionalField(StrFixedLenField("security_key", None, 256), lambda pkt:pkt.opcode == 0x07 or (pkt.opcode == 0x08 and pkt.flag == 0x03)),
 
         # Security Key 2 fields
-        ConditionalField(IPField("security2_addressv4", "0.0.0.0"), lambda pkt:pkt.opcode == 0x09),
-        ConditionalField(ShortField("security2_port", 0), lambda pkt:pkt.opcode == 0x09),
-        ConditionalField(StrFixedLenField("security2_key", None, 256), lambda pkt:pkt.opcode == 0x09),
-        ConditionalField(IP6Field("security2_addressv6", "::"), lambda pkt:pkt.opcode == 0x09),
+        ConditionalField(IPField("security2_addressv4", "0.0.0.0"), lambda pkt:pkt.opcode == 0x09 and pkt.flag == 0x02 and pkt.opcode_version <= 0x01),
+        ConditionalField(IP6Field("security2_addressv6", "::"), lambda pkt:pkt.opcode == 0x09 and pkt.flag == 0x02 and pkt.opcode_version > 0x01),
+        ConditionalField(ShortField("security2_port", 0), lambda pkt:pkt.opcode == 0x09 and pkt.flag == 0x02),
+        ConditionalField(StrFixedLenField("security2_key", None, 256), lambda pkt:pkt.opcode == 0x09 and pkt.flag == 0x03),
 
         # Hardware ID field
-        ConditionalField(StrNullFixedLenField("hwid", b"", length=99), lambda pkt:pkt.opcode == 0x0a),
+        ConditionalField(StrField("hwid_request_magic", b""), lambda pkt:pkt.opcode == 0x0a and pkt.flag == 0x02),
+        ConditionalField(StrFixedLenField("hwid", b"", length=100), lambda pkt:pkt.opcode == 0x0a and pkt.flag == 0x03),
 
         # Statistics
-        ConditionalField(PacketField("stats", None, SAPMSStat3), lambda pkt:pkt.opcode == 0x11 and pkt.flag == 0x03 and pkt.opcode_error == 0x00),
+        ConditionalField(StrField("stats", b""),
+            lambda pkt:pkt.opcode == 0x11 and pkt.flag == 0x03 and pkt.opcode_error == 0x00),
+
+        # Open request list
+        ConditionalField(PacketField("open_requests", None, SAPMSOpenRequestList),
+                         lambda pkt:pkt.opcode == 0x14 and pkt.flag == 0x03 and pkt.opcode_error == 0x00),
 
         # Codepage
         ConditionalField(IntField("codepage", 0), lambda pkt:pkt.opcode == 0x1c and pkt.flag == 0x03 and pkt.opcode_error == 0x00),
@@ -1276,10 +1366,18 @@ class SAPMS(Packet):
         ConditionalField(ShortField("dump_index", 0x00), lambda pkt:pkt.opcode == 0x1E and pkt.flag == 0x02),
         ConditionalField(ShortEnumKeysField("dump_command", 0x01, ms_dump_command_values), lambda pkt:pkt.opcode == 0x1E and pkt.flag == 0x02),
         ConditionalField(StrFixedLenField("dump_name", b"\x00" * 40, 40), lambda pkt:pkt.opcode == 0x1E and pkt.flag == 0x02),
+        ConditionalField(StrField("dump_response", b""), lambda pkt:pkt.opcode == 0x1E and pkt.flag == 0x03),
 
         # File Reload fields
         ConditionalField(ByteEnumKeysField("file_reload", 0, ms_file_reload_values), lambda pkt:pkt.opcode == 0x1f),
-        ConditionalField(StrFixedLenField("file_padding", b"\x00\x00", 2), lambda pkt:pkt.opcode == 0x1f),
+        ConditionalField(StrFixedLenField("file_padding", b"\x00\x00\x00", 3), lambda pkt:pkt.opcode == 0x1f),
+
+        # NI trace set/get
+        ConditionalField(StrFixedLenField("nitrace_client", b"", 40), lambda pkt:pkt.opcode == 0x3f and (pkt.flag == 0x02 or pkt.opcode_error == 0)),
+        ConditionalField(ByteField("nitrace_padding1", 0), lambda pkt:pkt.opcode == 0x3f and (pkt.flag == 0x02 or pkt.opcode_error == 0)),
+        ConditionalField(ByteField("nitrace_operation", 0), lambda pkt:pkt.opcode == 0x3f and (pkt.flag == 0x02 or pkt.opcode_error == 0)),
+        ConditionalField(ByteField("nitrace_padding2", 0), lambda pkt:pkt.opcode == 0x3f and (pkt.flag == 0x02 or pkt.opcode_error == 0)),
+        ConditionalField(ByteField("nitrace_level", 0), lambda pkt:pkt.opcode == 0x3f and (pkt.flag == 0x02 or pkt.opcode_error == 0)),
 
         # Get/Set/Del Logon fields
         ConditionalField(MultipleTypeField([
@@ -1296,18 +1394,29 @@ class SAPMS(Packet):
         ConditionalField(PacketField("property", None, SAPMSProperty), lambda pkt:pkt.opcode in [0x43, 0x44, 0x45]),
 
         # IP/Port to name fields
-        ConditionalField(IPField("ip_to_name_address4", "0.0.0.0"), lambda pkt:pkt.opcode == 0x46 and pkt.opcode_version == 0x01),
+        ConditionalField(IPField("ip_to_name_address4", "0.0.0.0"), lambda pkt:pkt.opcode == 0x46 and pkt.opcode_version in [0x00, 0x01]),
         ConditionalField(IP6Field("ip_to_name_address6", "::"), lambda pkt:pkt.opcode == 0x46 and pkt.opcode_version == 0x02),
         ConditionalField(ShortField("ip_to_name_port", 0), lambda pkt:pkt.opcode == 0x46),
         ConditionalField(FieldLenField("ip_to_name_length", None, length_of="ip_to_name", fmt="!I"), lambda pkt:pkt.opcode == 0x46),
         ConditionalField(StrLenField("ip_to_name", b"", length_from=lambda pkt:pkt.ip_to_name_length), lambda pkt:pkt.opcode == 0x46),
 
         # Check ACL fields
-        ConditionalField(ShortField("error_code", 0), lambda pkt:pkt.opcode == 0x47),
-        ConditionalField(StrFixedLenField("acl", b"", 46), lambda pkt:pkt.opcode == 0x47),
+        ConditionalField(IP6Field("check_acl_address", "::"), lambda pkt:pkt.opcode == 0x47 and pkt.flag == 0x02 and pkt.opcode_version == 0x02),
+        ConditionalField(ShortEnumField("error_code", 0, ms_opcode_error_values), lambda pkt:pkt.opcode == 0x47 and pkt.flag == 0x03),
+        ConditionalField(StrField("acl", b""), lambda pkt:pkt.opcode == 0x47 and pkt.flag == 0x03),
 
         # Get system ID field
         ConditionalField(StrFixedLenField("sid", b"", 8), lambda pkt: pkt.opcode == 0x4e and pkt.flag == 0x03 and pkt.opcode_error == 0x00),
+
+        # Message Server log counter
+        ConditionalField(PacketField("log_counter", None, SAPMSLogCounter),
+                         lambda pkt:pkt.opcode == 0x50 and pkt.flag == 0x03 and pkt.opcode_error == 0x00),
+
+        # ASCS gateway logon/status and keepalive payloads
+        ConditionalField(PacketField("ascs_gateway", None, SAPMSASCSGatewayLogon),
+                         lambda pkt:pkt.opcode == 0x52 or (pkt.opcode == 0x53 and pkt.flag == 0x03 and pkt.opcode_error == 0x00)),
+        ConditionalField(PacketField("ascs_gateway_keepalive", None, SAPMSASCSGatewayKeepalive),
+                         lambda pkt:pkt.opcode == 0x54 and pkt.flag == 0x02),
     ]
 
 

--- a/tests/examples_regression_test.py
+++ b/tests/examples_regression_test.py
@@ -13,10 +13,12 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
-from pysap.SAPMS import SAPMS
+from pysap.SAPMS import (SAPMS, SAPMSAdmRecord, SAPMSClient3,
+                         SAPMSLogonResponse, SAPMSProperty,
+                         ms_logon_type_values, ms_property_id_values)
 from pysap.SAPNI import SAPNI
 
-from examples import ms_impersonator, router_password_check
+from examples import ms_impersonator, ms_monitor, router_password_check
 
 
 class FakeTimingSocket(object):
@@ -38,6 +40,128 @@ class FakeTimingSocket(object):
 
 
 class PySAPExamplesRegressionTest(unittest.TestCase):
+
+    def test_ms_monitor_dump_all_uses_parsed_commands_and_dump_response(self):
+        options = SimpleNamespace(client="test", domain="ABAP",
+                                  consolelog=None, verbose=False)
+        console = ms_monitor.SAPMSMonitorConsole(options)
+        console._send_simple = mock.Mock(
+            return_value=SimpleNamespace(dump_response=b"dump output\x00"))
+        console._print = mock.Mock()
+
+        console.do_dump("all")
+
+        commands = [call.kwargs["dump_command"]
+                    for call in console._send_simple.call_args_list]
+        self.assertEqual(commands, [command for command in range(1, 33)
+                                    if command not in (1, 12)])
+        console._print.assert_any_call("Dump information:\ndump output")
+        console._print.assert_any_call(
+            "Skipping MS_DUMP_MSADM: requires an argument")
+        console._print.assert_any_call(
+            "Skipping MS_DUMP_COUNTER: requires an argument")
+
+    def test_ms_monitor_preserves_spaces_in_command_values(self):
+        options = SimpleNamespace(client="test", domain="ABAP",
+                                  consolelog=None, verbose=False)
+        console = ms_monitor.SAPMSMonitorConsole(options)
+        console.connected = True
+        console.clients = [SAPMSClient3(client="SERVER")]
+        console.runtimeoptions.update(server_string=b"MSG_SERVER",
+                                      client_string=b"test")
+        console._send_simple = mock.Mock(return_value=None)
+        response = SAPMS(flag=0x04, iflag=0x05, adm_records=[
+            SAPMSAdmRecord(opcode=0x2e, errorno=0)])
+        console.connection = SimpleNamespace(sr=mock.Mock(return_value=response))
+
+        console.do_server_disconnect("0 planned maintenance window")
+        console.do_parameter_set("ms/example value with spaces")
+
+        self.assertEqual(
+            console._send_simple.call_args.kwargs["shutdown_reason"],
+            "planned maintenance window")
+        request = console.connection.sr.call_args.args[0]
+        self.assertEqual(request.adm_records[0].parameter.rstrip(b"\x00"),
+                         b"ms/example=value with spaces")
+
+    def test_ms_monitor_expanded_opcode_commands(self):
+        options = SimpleNamespace(client="test", domain="ABAP",
+                                  consolelog=None, verbose=False)
+        console = ms_monitor.SAPMSMonitorConsole(options)
+        console.connected = True
+        console.clients = [SAPMSClient3(client="SERVER")]
+        console.runtimeoptions.update(server_string=b"MSG_SERVER",
+                                      client_string=b"test")
+        response = SimpleNamespace(
+            ip_to_name=b"SERVER\x00", text_value=b"description\x00",
+            property=SAPMSProperty(client="SERVER", id=1),
+            logon=SAPMSLogonResponse())
+        console._send_simple = mock.Mock(return_value=response)
+        console._print = mock.Mock()
+
+        console.do_set_security_key("SERVER secret")
+        console.do_ip_port_to_name("2001:db8::1 3200")
+        console.do_change_ip("127.0.0.2")
+        console.do_noop("")
+        console.do_file_reload("4")
+        console.do_set_logon("6 PUBLIC 127.0.0.1 50000 HTTP host misc")
+        console.do_del_logon("6 PUBLIC")
+        console.do_text_set("SERVER description")
+        console.do_text_get("SERVER")
+        console.do_property_set("0 1 description")
+        console.do_property_delete("0 1")
+        console.do_subsystem_list("")
+        console.do_soft_shutdown("")
+
+        opcodes = [call.kwargs["opcode"]
+                   for call in console._send_simple.call_args_list]
+        self.assertEqual(opcodes, [0x07, 0x46, 0x06, 0x21, 0x1f, 0x2b,
+                                   0x2d, 0x22, 0x23, 0x43, 0x45, 0x4d,
+                                   0x1d])
+        self.assertEqual(console._send_simple.call_args_list[1].kwargs,
+                         {"opcode": 0x46, "opcode_version": 2,
+                          "ip_to_name_port": 3200,
+                          "ip_to_name_address6": "2001:db8::1"})
+        self.assertEqual(
+            console._send_simple.call_args_list[5].kwargs["logon"].misc,
+            b"misc")
+
+    def test_ms_monitor_logon_group_command_is_not_client_list_alias(self):
+        options = SimpleNamespace(client="test", domain="ABAP",
+                                  consolelog=None, verbose=False)
+        console = ms_monitor.SAPMSMonitorConsole(options)
+        console.do_dump = mock.Mock()
+        console.do_client_list = mock.Mock()
+
+        console.do_logon_group_list("")
+
+        self.assertEqual(console.do_dump.call_args_list,
+                         [mock.call("31"), mock.call("32")])
+        console.do_client_list.assert_not_called()
+
+    def test_ms_monitor_argument_completion(self):
+        options = SimpleNamespace(client="test", domain="ABAP",
+                                  consolelog=None, verbose=False)
+        console = ms_monitor.SAPMSMonitorConsole(options)
+        console.clients = [SAPMSClient3(client="SERVER"),
+                           SAPMSClient3(client="SENDER")]
+
+        self.assertEqual(console.complete_dump("3", "dump 3", 5, 6),
+                         ["3", "30", "31", "32"])
+        self.assertEqual(console.complete_dump("", "dump 1 ", 7, 7),
+                         ["0", "1"])
+        self.assertEqual(console.complete_file_reload(
+            "1", "file_reload 1", 12, 13),
+            ["1", "10", "11", "12", "13", "14", "15"])
+        self.assertEqual(console.complete_get_logon(
+            "1", "get_logon PUBLIC 1", 17, 18),
+            sorted(str(value) for value in ms_logon_type_values
+                   if str(value).startswith("1")))
+        self.assertEqual(console.complete_property_get(
+            "", "property_get 0 ", 15, 15),
+            sorted(str(value) for value in ms_property_id_values))
+        self.assertEqual(console.complete_text_get(
+            "SE", "text_get SE", 9, 11), ["SENDER", "SERVER"])
 
     def test_ms_impersonator_requires_sapms_layer(self):
         response = SAPMS()

--- a/tests/sapms_test.py
+++ b/tests/sapms_test.py
@@ -17,8 +17,13 @@
 import sys
 import unittest
 
-from pysap.SAPMS import (SAPMS, SAPMSAdmRecord, SAPMSClient1, SAPMSLogon,
-                         SAPMSLogonResponse, SAPMSProperty, SAPMSJ2EEHeader)
+from pysap.SAPMS import (SAPMS, SAPMSAdmRecord, SAPMSASCSGatewayLogon,
+                         SAPMSASCSGatewayLogonTag, SAPMSASCSGatewayKeepalive,
+                         SAPMSClient1, SAPMSLogon,
+                         SAPMSLogCounter, SAPMSLogCounterRecord,
+                         SAPMSLogonResponse, SAPMSOpenRequest,
+                         SAPMSOpenRequestList, SAPMSProperty,
+                         SAPMSJ2EEHeader)
 from tests.utils import roundtrip_packet
 
 
@@ -52,6 +57,66 @@ class PySAPMessageServerTest(unittest.TestCase):
         self.assertEqual(parsed.supplvl, 2)
         self.assertEqual(parsed.platform, 3)
 
+    def test_property_raw_value_roundtrip(self):
+        parsed = roundtrip_packet(SAPMSProperty(client="CLIENT", id=0x08,
+                                                raw_value=b"opaque"))
+
+        self.assertEqual(parsed.id, 0x08)
+        self.assertEqual(parsed.raw_value, b"opaque")
+
+    def test_security_key_direction_and_version_roundtrip(self):
+        request = roundtrip_packet(SAPMS(flag=0x02, iflag=0x01, opcode=0x08,
+                                         security_name=b"CLIENT"))
+        response = roundtrip_packet(SAPMS(flag=0x03, iflag=0x01, opcode=0x08,
+                                          security_key=b"K" * 256))
+        request_v2 = roundtrip_packet(SAPMS(flag=0x02, iflag=0x01, opcode=0x09,
+                                            opcode_version=2,
+                                            security2_addressv6="2001:db8::1",
+                                            security2_port=3200))
+
+        self.assertEqual(request.security_name.rstrip(b"\x00"), b"CLIENT")
+        self.assertEqual(response.security_key, b"K" * 256)
+        self.assertEqual(request_v2.security2_addressv6, "2001:db8::1")
+        self.assertEqual(request_v2.security2_port, 3200)
+
+    def test_hwid_and_dump_direction_roundtrip(self):
+        request = roundtrip_packet(SAPMS(flag=0x02, iflag=0x01, opcode=0x0a,
+                                         hwid_request_magic=b"HWID"))
+        response = roundtrip_packet(SAPMS(flag=0x03, iflag=0x01, opcode=0x0a,
+                                          hwid=b"H" * 100))
+        dump = roundtrip_packet(SAPMS(flag=0x03, iflag=0x01, opcode=0x1e,
+                                      dump_response=b"one\ntwo\n"))
+
+        self.assertEqual(request.hwid_request_magic, b"HWID")
+        self.assertEqual(response.hwid, b"H" * 100)
+        self.assertEqual(dump.dump_response, b"one\ntwo\n")
+
+    def test_opcode_structures_roundtrip(self):
+        stats = roundtrip_packet(SAPMS(
+            flag=0x03, iflag=0x01, opcode=0x11, opcode_version=3,
+            stats=b"S" * 712))
+        requests = roundtrip_packet(SAPMS(
+            flag=0x03, iflag=0x01, opcode=0x14,
+            open_requests=SAPMSOpenRequestList(requests=[
+                SAPMSOpenRequest(data=b"R" * 88)])))
+        nitrace = roundtrip_packet(SAPMS(
+            flag=0x02, iflag=0x01, opcode=0x3f,
+            nitrace_client=b"CLIENT", nitrace_operation=1,
+            nitrace_level=2))
+        log_counter = roundtrip_packet(SAPMS(
+            flag=0x03, iflag=0x01, opcode=0x50,
+            log_counter=SAPMSLogCounter(index=3, records=[
+                SAPMSLogCounterRecord(data=b"L" * 48)])))
+
+        self.assertEqual(stats.stats, b"S" * 712)
+        self.assertEqual(len(bytes(stats)), 114 + 712)
+        self.assertEqual(len(requests.open_requests.requests), 1)
+        self.assertEqual(requests.open_requests.requests[0].data, b"R" * 88)
+        self.assertEqual(nitrace.nitrace_operation, 1)
+        self.assertEqual(nitrace.nitrace_level, 2)
+        self.assertEqual(log_counter.log_counter.index, 3)
+        self.assertEqual(log_counter.log_counter.count, 1)
+
     def test_j2ee_header_roundtrip(self):
         parsed = roundtrip_packet(SAPMSJ2EEHeader())
 
@@ -77,7 +142,7 @@ class PySAPMessageServerTest(unittest.TestCase):
             self.assertEqual(parsed.shutdown_reason, b"maintenance")
 
     def test_message_server_ip_to_name_roundtrip(self):
-        packet = SAPMS(iflag=0x01, opcode=0x46,
+        packet = SAPMS(iflag=0x01, opcode=0x46, opcode_version=0,
                        ip_to_name_address4="127.0.0.1",
                        ip_to_name_port=3200,
                        ip_to_name="server.example")
@@ -87,6 +152,56 @@ class PySAPMessageServerTest(unittest.TestCase):
         self.assertEqual(parsed.ip_to_name_address4, "127.0.0.1")
         self.assertEqual(parsed.ip_to_name_port, 3200)
         self.assertEqual(parsed.ip_to_name, b"server.example")
+
+    def test_message_server_check_acl_roundtrip(self):
+        request = roundtrip_packet(SAPMS(
+            flag=0x02, iflag=0x01, opcode=0x47, opcode_version=2,
+            check_acl_address="2001:db8::1"))
+        response = roundtrip_packet(SAPMS(
+            flag=0x03, iflag=0x01, opcode=0x47, opcode_version=2,
+            error_code=0, acl=b"ALLOW\x00HOST=*\x00"))
+
+        self.assertEqual(request.check_acl_address, "2001:db8::1")
+        self.assertEqual(response.error_code, 0)
+        self.assertEqual(response.acl, b"ALLOW\x00HOST=*\x00")
+
+    def test_message_server_ascs_gateway_logon_roundtrip(self):
+        packet = SAPMS(
+            flag=0x02, iflag=0x01, opcode=0x52,
+            ascs_gateway=SAPMSASCSGatewayLogon(tags=[
+                SAPMSASCSGatewayLogonTag(tag=1, value=3301),
+                SAPMSASCSGatewayLogonTag(tag=2, value=3302),
+                SAPMSASCSGatewayLogonTag(tag=3, value=1234),
+                SAPMSASCSGatewayLogonTag(tag=4, value="2001:db8::1"),
+                SAPMSASCSGatewayLogonTag(tag=0),
+            ]))
+        parsed = roundtrip_packet(packet)
+
+        self.assertEqual([tag.tag for tag in parsed.ascs_gateway.tags],
+                         [1, 2, 3, 4, 0])
+        self.assertEqual(parsed.ascs_gateway.tags[0].value, 3301)
+        self.assertEqual(parsed.ascs_gateway.tags[3].value, "2001:db8::1")
+
+    def test_message_server_ascs_gateway_status_and_keepalive_roundtrip(self):
+        status_request = roundtrip_packet(SAPMS(
+            flag=0x02, iflag=0x01, opcode=0x53))
+        status_response = roundtrip_packet(SAPMS(
+            flag=0x03, iflag=0x01, opcode=0x53,
+            ascs_gateway=SAPMSASCSGatewayLogon(tags=[
+                SAPMSASCSGatewayLogonTag(tag=1, value=3301),
+                SAPMSASCSGatewayLogonTag(tag=0),
+            ])))
+        keepalive_request = roundtrip_packet(SAPMS(
+            flag=0x02, iflag=0x01, opcode=0x54,
+            ascs_gateway_keepalive=SAPMSASCSGatewayKeepalive()))
+        keepalive_response = roundtrip_packet(SAPMS(
+            flag=0x03, iflag=0x01, opcode=0x54))
+
+        self.assertFalse(status_request.haslayer(SAPMSASCSGatewayLogon))
+        self.assertEqual(status_response.ascs_gateway.tags[0].value, 3301)
+        self.assertEqual(len(keepalive_request.ascs_gateway_keepalive.data),
+                         0x1030)
+        self.assertFalse(keepalive_response.haslayer(SAPMSASCSGatewayKeepalive))
 
     def test_message_server_logon_request_roundtrip(self):
         packet = SAPMS(flag=0x02, iflag=0x01, opcode=0x2c,


### PR DESCRIPTION
- Expand SAPMS opcode, error, and payload coverage, including ASCS gateway, monitor, ACL, open-request, and log-counter operations. Update Message Server examples, tests, documentation, and protocol notebook accordingly.
- Enabled console tab completion